### PR TITLE
Install argparse package on lucid (package < v2.7)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,6 +9,15 @@ package yaml do
   action :install
 end
 
+ohai "python-version" do
+  plugin "python"
+  action :reload
+end
+
+if Gem::Version.new(node['languages']['python']['version']) < Gem::Version.new("2.7")
+  python_pip "argparse"
+end
+
 unless node['jenkins_job_builder']['from_source']
   python_pip 'jenkins-job-builder' do
     version node['jenkins_job_builder']['version']


### PR DESCRIPTION
Ubuntu lucid ships with the default python package that's 2.6.x, which doesn't come with argparse. This should do the trick, but untested:

``` rb
case node['platform_family']
when "debian"
  if node['python']['install_method'] == "package" && node['platform'].to_i == 10
    python_pip "argparse"
  end
end
```

I'll submit a PR when I get a sec :)
