### PR TITLE
Update use of deprecated Chef::ShellOut

### DIFF
--- a/definitions/build_jenkins_job.rb
+++ b/definitions/build_jenkins_job.rb
@@ -5,11 +5,18 @@ define :build_jenkins_job, :delete => false, :config_path => '/etc/jenkins_jobs/
     raise
   end
 
+  # Since Chef::ShellOut is deprecated in Chef 11.
+  if Gem::Version.new(Chef::VERSION) < Gem::Version.new("11")
+    shellout_module = "Chef"
+  else
+    shellout_module = "Mixlib"
+  end
+
   unless params[:delete]
     ruby_block "update #{params[:name]} job config" do
       block do
         Chef::Log.info("build_jenkins_job: updating jobs from #{params[:job_config]}")
-        update_job = Chef::ShellOut.new("jenkins-jobs --conf #{params[:config_path]} update #{params[:job_config]}").run_command
+        update_job = Module.const_get(shellout_module)::ShellOut.new("jenkins-jobs --conf #{params[:config_path]} update #{params[:job_config]}").run_command
         Chef::Log.debug("build_jenkins_job: " + update_job.format_for_exception)
         unless update_job.status == 0
           Chef::Log.fatal('build_jenkins_job: error updating job: ' + update_job.format_for_exception)
@@ -21,7 +28,7 @@ define :build_jenkins_job, :delete => false, :config_path => '/etc/jenkins_jobs/
     ruby_block "delete #{params[:name]} job config" do
       block do
         Chef::Log.info("build_jenkins_job: deleting job #{params[:name]}")
-        delete_job = Chef::ShellOut.new("jenkins-jobs --conf #{params[:config_path]} delete #{params[:name]}").run_command
+        delete_job = Module.const_get(shellout_module)::ShellOut.new("jenkins-jobs --conf #{params[:config_path]} delete #{params[:name]}").run_command
         Chef::Log.debug("build_jenkins_job: " + delete_job.format_for_exception)
         unless delete_job.status == 0
           Chef::Log.fatal('build_jenkins_job: error deleting job: ' + delete_job.format_for_exception)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,6 +9,15 @@ package yaml do
   action :install
 end
 
+ohai "python-version" do
+  plugin "python"
+  action :reload
+end
+
+if Gem::Version.new(node['python']['version']) < Gem::Version.new("2.7")
+  python_pip "argparse"
+end
+
 unless node['jenkins_job_builder']['from_source']
   python_pip 'jenkins-job-builder' do
     version node['jenkins_job_builder']['version']


### PR DESCRIPTION
This is what I get after each `build_jenkins_job` resource using Chef 11:

```
[2013-07-17T06:28:23+02:00] WARN: Chef::ShellOut is deprecated, please use Mixlib::ShellOut
[2013-07-17T06:28:23+02:00] WARN: Called from:
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/jenkins-job-builder/definitions/build_jenkins_job.rb:12:in `new'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/jenkins-job-builder/definitions/build_jenkins_job.rb:12:in `block (3 levels) in from_file'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/provider/ruby_block.rb:33:in `call'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/provider/ruby_block.rb:33:in `block in action_run'
```

Perhaps we could check the chef version and run Mixlib::ShellOut otherwise.
