### PR TITLE
Remove `external_url` from ini so that works with jenkins cookbook v2

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,6 @@ template '/etc/jenkins_jobs/jenkins_jobs.ini' do
     :username => node['jenkins_job_builder']['username'],
     :password => node['jenkins_job_builder']['password'],
     :url => node['jenkins_job_builder']['url'],
-    :external_url => node['jenkins']['server']['url'],
     :hipchat_token => node['jenkins_job_builder']['hipchat_token']
   })
 end

--- a/templates/default/jenkins_jobs.ini.erb
+++ b/templates/default/jenkins_jobs.ini.erb
@@ -2,7 +2,6 @@
 user=<%= @username %>
 password=<%= @password %>
 url=<%= @url %>
-external_url=<%= @external_url %>
 <%- if @hipchat_token -%>
 [hipchat]
 authtoken=<%= @hipchat_token %>


### PR DESCRIPTION
## Problem

This cookbook causes the chef run to fail if using jenkins cookbook >= 2.0.0.
## Context

jenkins-job-builder's ini no longer requires `external_url` (replaced by `url`?):
http://ci.openstack.org/jjb.html#sending-a-job-to-jenkins

Currently, this cookbook depends on a `node['jenkins']['server']['url']` being set:
https://github.com/needle-cookbooks/chef-jenkins-job-builder/blob/master/templates/default/jenkins_jobs.ini.erb#L5

However, this is no longer an attribute in the redesigned jenkins cookbook, and the closest thing is [`node['jenkins']['master']['host']`](https://github.com/needle-cookbooks/chef-jenkins-job-builder/blob/master/templates/default/jenkins_jobs.ini.erb#L5) (which still might not be right to hardcode).
## Solution

Can we simply remove that line so that this cookbook will work with the new jenkins cookbook?
